### PR TITLE
Add RWX cloning/snapshot tests

### DIFF
--- a/test/e2e/cloud-provider-oci/csi_rwx_snapshot_restore.go
+++ b/test/e2e/cloud-provider-oci/csi_rwx_snapshot_restore.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+)
+
+var _ = Describe("RWX Raw Block Volume Snapshot Creation and Restore", func() {
+	f := framework.NewBackupFramework("snapshot-restore")
+
+	Context("[cloudprovider][storage][csi][snapshot][restore][raw-block][rwx]", func() {
+		It("Should be able to schedule a pod on each worker node after creating a snapshot and restore from a RWX raw block backup", func() {
+			checkOrInstallCRDs(f)
+			scParams := map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI}
+			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-snapshot-restore-e2e-tests")
+
+			nodes := pvcJig.ListSchedulableNodesInAD(setupF.AdLabel)
+			if len(nodes) < 2 {
+				Skip(fmt.Sprintf("at least 2 schedulable nodes in a AD is required to test MULTI_NODE %s", f.Namespace.Name))
+			}
+
+			pvcJig.InitialiseSnapClient(f.SnapClientSet)
+
+			volId := pvcJig.CreateVolume(f.BlockStorageClient, setupF.AdLocation, setupF.StaticSnapshotCompartmentOcid, "test-volume", 10)
+			//wait for volume to become available
+			time.Sleep(15 * time.Second)
+
+			backupOCID := pvcJig.CreateVolumeBackup(f.BlockStorageClient, setupF.AdLabel, setupF.StaticSnapshotCompartmentOcid, *volId, "test-backup")
+
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, BVDriverName, scParams, pvcJig.Labels, BindingModeWaitForFirstConsumer, true, ReclaimPolicyDelete, nil)
+
+			//creating a snapshot statically using the backup provisioned dynamically
+			restoreVsName := "e2e-restore-vs"
+			vscontentName := pvcJig.CreateVolumeSnapshotContentOrFail(f.Namespace.Name+"-e2e-snapshot-vsc", BVDriverName, *backupOCID, ReclaimPolicyDelete, restoreVsName, f.Namespace.Name, v1.PersistentVolumeBlock)
+
+			pvcJig.CreateAndAwaitVolumeSnapshotStaticOrFail(restoreVsName, f.Namespace.Name, vscontentName)
+
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ReadWriteMany, v1.ClaimPending, true, nil)
+
+			//wait for volume to be restored before starting cleanup
+			time.Sleep(30 * time.Second)
+
+			// schedule a pod on each available node
+			for range nodes {
+				pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommandBlock)
+			}
+
+			//cleanup
+			pvcJig.DeleteVolume(f.BlockStorageClient, *volId)
+			pvcJig.DeleteVolumeBackup(f.BlockStorageClient, *backupOCID)
+			f.VolumeIds = append(f.VolumeIds, pvcRestore.Spec.VolumeName, *volId)
+			_ = f.DeleteVolumeSnapshotClass(f.Namespace.Name)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
+		})
+	})
+})

--- a/test/e2e/cloud-provider-oci/csi_rwx_volume_cloning.go
+++ b/test/e2e/cloud-provider-oci/csi_rwx_volume_cloning.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("CSI RWX Block Volume Creation with PVC datasource", func() {
+	f := framework.NewDefaultFramework("csi-volume-cloning")
+	Context("[cloudprovider][storage][csi][cloning][raw-block][rwx]", func() {
+		It("Check RWX Funtionality with Cloned raw block PVC", func() {
+			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-cloning-basic")
+
+			nodes := pvcJig.ListSchedulableNodesInAD(setupF.AdLabel)
+			if len(nodes) < 2 {
+				Skip(fmt.Sprintf("at least 2 schedulable nodes in a AD is required to test MULTI_NODE %s", f.Namespace.Name))
+			}
+
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeBlock, v1.ReadWriteMany, v1.ClaimPending)
+			srcPod := pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
+
+			time.Sleep(60 * time.Second) // Wait for data to be written to source PV
+
+			clonePvc := pvcJig.CreateAndAwaitClonePVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, srcPvc.Name, nil, v1.PersistentVolumeBlock, v1.ReadWriteMany, v1.ClaimPending)
+			var clonePodList []string
+			// schedule a pod on each available node
+			for i := range nodes {
+				clonePod := pvcJig.NewPodForCSIwAntiAffinity(fmt.Sprintf("pod-%d", i), f.Namespace.Name, clonePvc.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
+				clonePodList = append(clonePodList, clonePod)
+				// Wait for data to be written to cloned PV
+				time.Sleep(60 * time.Second)
+
+				pvcJig.CheckDataInBlockDevice(f.Namespace.Name, clonePod, "Hello World")
+				pvcJig.ExtractDataFromBlockDevice(f.Namespace.Name, clonePod, "/dev/xvda", "/tmp/testdata.txt")
+				pvcJig.CheckFileCorruption(f.Namespace.Name, clonePod, "/tmp", "testdata.txt")
+			}
+
+			// clean up
+			pvcJig.DeleteAndAwaitPod(f.Namespace.Name, srcPod)
+			pvcJig.DeleteAndAwaitPVC(f.Namespace.Name, srcPvc.Name)
+
+			for _, pod := range clonePodList {
+				pvcJig.DeleteAndAwaitPod(f.Namespace.Name, pod)
+			}
+			f.VolumeIds = append(f.VolumeIds, srcPvc.Spec.VolumeName, clonePvc.Spec.VolumeName)
+			pvcJig.DeleteAndAwaitPVC(f.Namespace.Name, clonePvc.Name)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
+		})
+
+		It("Check RWO Funtionality with Cloned RWO raw block PVC from RWX source PVC", func() {
+			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-cloning-basic")
+
+			nodes := pvcJig.ListSchedulableNodesInAD(setupF.AdLabel)
+			if len(nodes) < 2 {
+				Skip(fmt.Sprintf("at least 2 schedulable nodes in a AD is required to test MULTI_NODE %s", f.Namespace.Name))
+			}
+
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeBlock, v1.ReadWriteMany, v1.ClaimPending)
+			srcPod := pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
+
+			time.Sleep(60 * time.Second) // Wait for data to be written to source PV
+
+			clonePvc := pvcJig.CreateAndAwaitClonePVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, srcPvc.Name, nil, v1.PersistentVolumeBlock, v1.ReadWriteOnce, v1.ClaimPending)
+			clonePod := pvcJig.NewPodForCSIClone("app2", f.Namespace.Name, clonePvc.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
+
+			pvcJig.CheckDataInBlockDevice(f.Namespace.Name, clonePod, "Hello World")
+			pvcJig.ExtractDataFromBlockDevice(f.Namespace.Name, clonePod, "/dev/xvda", "/tmp/testdata.txt")
+			pvcJig.CheckFileCorruption(f.Namespace.Name, clonePod, "/tmp", "testdata.txt")
+
+			// clean up
+			pvcJig.DeleteAndAwaitPod(f.Namespace.Name, srcPod)
+			pvcJig.DeleteAndAwaitPVC(f.Namespace.Name, srcPvc.Name)
+			pvcJig.DeleteAndAwaitPod(f.Namespace.Name, clonePod)
+			pvcJig.DeleteAndAwaitPVC(f.Namespace.Name, clonePvc.Name)
+			f.VolumeIds = append(f.VolumeIds, srcPvc.Spec.VolumeName, clonePvc.Spec.VolumeName)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
+		})
+	})
+})

--- a/test/e2e/cloud-provider-oci/csi_snapshot_restore.go
+++ b/test/e2e/cloud-provider-oci/csi_snapshot_restore.go
@@ -148,7 +148,7 @@ var _ = Describe("Snapshot Creation and Restore", func() {
 
 			pvcJig.CreateAndAwaitVolumeSnapshotStaticOrFail(restoreVsName, f.Namespace.Name, vscontentName)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ClaimPending, false, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ReadWriteOnce, v1.ClaimPending, false, nil)
 			podRestoreName := pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommand)
 
 			pvcJig.CheckFileExists(f.Namespace.Name, podRestoreName, "/usr/share/nginx/html", "testdata.txt")
@@ -177,7 +177,7 @@ var _ = Describe("Snapshot Creation and Restore", func() {
 
 			pvcJig.CreateAndAwaitVolumeSnapshotStaticOrFail(restoreVsName, f.Namespace.Name, vscontentName)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ClaimPending, false, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ReadWriteOnce, v1.ClaimPending, false, nil)
 			pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommand)
 
 			//wait for volume to be restored before starting cleanup
@@ -239,7 +239,7 @@ var _ = Describe("Raw Block Volume Snapshot Creation and Restore", func() {
 			vscName := f.CreateVolumeSnapshotClassOrFail(f.Namespace.Name, BVDriverName, vscParams, ReclaimPolicyDelete)
 			vs := pvcJig.CreateAndAwaitVolumeSnapshotOrFail(f.Namespace.Name, vscName, pvc.Name, nil)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MaxVolumeBlock, scName, vs.Name, v1.ClaimPending, true, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MaxVolumeBlock, scName, vs.Name, v1.ReadWriteOnce, v1.ClaimPending, true, nil)
 			podRestoreName := pvcJig.NewPodForCSI("pod-restored", f.Namespace.Name, pvcRestore.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
 
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
@@ -267,7 +267,7 @@ var _ = Describe("Raw Block Volume Snapshot Creation and Restore", func() {
 			vscName := f.CreateVolumeSnapshotClassOrFail(f.Namespace.Name, BVDriverName, vscParams, ReclaimPolicyDelete)
 			vs := pvcJig.CreateAndAwaitVolumeSnapshotOrFail(f.Namespace.Name, vscName, pvc.Name, nil)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MaxVolumeBlock, scName, vs.Name, v1.ClaimPending, true, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MaxVolumeBlock, scName, vs.Name, v1.ReadWriteOnce, v1.ClaimPending, true, nil)
 			podRestoreName := pvcJig.NewPodForCSI("pod-restored", f.Namespace.Name, pvcRestore.Name, setupF.AdLabel, v1.PersistentVolumeBlock)
 
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
@@ -305,7 +305,7 @@ var _ = Describe("Raw Block Volume Snapshot Creation and Restore", func() {
 
 			pvcJig.CreateAndAwaitVolumeSnapshotStaticOrFail(restoreVsName, f.Namespace.Name, vscontentName)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ClaimPending, true, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ReadWriteOnce, v1.ClaimPending, true, nil)
 			podRestoreName := pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommandBlock)
 			pvcJig.CheckDataInBlockDevice(f.Namespace.Name, podRestoreName, "Hello World")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
@@ -332,7 +332,7 @@ var _ = Describe("Raw Block Volume Snapshot Creation and Restore", func() {
 
 			pvcJig.CreateAndAwaitVolumeSnapshotStaticOrFail(restoreVsName, f.Namespace.Name, vscontentName)
 
-			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ClaimPending, true, nil)
+			pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, restoreVsName, v1.ReadWriteOnce, v1.ClaimPending, true, nil)
 			pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommandBlock)
 
 			//wait for volume to be restored before starting cleanup
@@ -555,13 +555,13 @@ func testSnapshotAndRestore(f *framework.CloudProviderFramework, scParams map[st
 	vs := pvcJig.CreateAndAwaitVolumeSnapshotOrFail(f.Namespace.Name, vscName, pvc.Name, nil)
 
 	if volumeMode == v1.PersistentVolumeFilesystem {
-		pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, vs.Name, v1.ClaimPending, false, nil)
+		pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, vs.Name, v1.ReadWriteOnce, v1.ClaimPending, false, nil)
 		podRestoreName := pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommand)
 
 		// Check if the file exists in the restored pod
 		pvcJig.CheckFileExists(f.Namespace.Name, podRestoreName, "/usr/share/nginx/html", "testdata.txt")
 	} else {
-		pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, vs.Name, v1.ClaimPending, true, nil)
+		pvcRestore := pvcJig.CreateAndAwaitPVCOrFailSnapshotSource(f.Namespace.Name, framework.MinVolumeBlock, scName, vs.Name, v1.ReadWriteOnce, v1.ClaimPending, true, nil)
 		podRestoreName := pvcJig.CreateAndAwaitNginxPodOrFail(f.Namespace.Name, pvcRestore, KeepAliveCommandBlock)
 
 		// Check data in block device for restored pod

--- a/test/e2e/framework/storageclass_util.go
+++ b/test/e2e/framework/storageclass_util.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
What's the problem that this PR is looking to solve:
--------
This PR aims to add unit tests to validate RWX functionality for Snapshot Restore and Cloning on RBV.

What's the solution to the above problem that's contained in this PR:
--------

- Snapshot

Add tests to check RWX functionality post-snapshot
Since snapshot functionality is already covered under RWO tests, the focus will be on ensuring RWX functionality after the snapshot is restored.
Access mode should not affect snapshot behavior.

- Cloning

Adds tests to check RWX functionality post-cloning. 
Since cloning functionality is already covered under RWO tests, the focus will be on ensuring RWX functionality after cloning.
Access mode should not affect cloning behavior.

Testing:
--------
Pass the Unit tests